### PR TITLE
Implement a decorator transformer API.

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,41 @@
+import { buildDecoratorFactories, FACTORIES, PropertyDecoratorFactory } from '..';
+
+describe('buildDecoratorFactories', () => {
+    it('produces new decorator factories', () => {
+        const noop = () => { };
+        const transformer = () => noop;
+
+        const factories = buildDecoratorFactories({
+            IsBoolean: transformer,
+            IsDate: transformer,
+            IsDateString: transformer,
+            IsEnum: transformer,
+            IsInteger: transformer,
+            IsNested: transformer,
+            IsString: transformer,
+            IsUUID: transformer,
+        });
+
+        expect(factories).toBeDefined();
+        expect(Object.keys(FACTORIES)).toEqual(Object.keys(factories));
+
+        Object.values(factories).forEach(
+            (factory: PropertyDecoratorFactory<unknown>) => {
+                const decorator = factory({});
+                expect(decorator).toEqual(noop);
+            },
+        );
+
+        const { IsString } = factories;
+
+        class Example {
+            @IsString({
+                optional: true,
+            })
+            foo?: string;
+        }
+
+        const example = new Example();
+        expect(example).toEqual({});
+    });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,87 @@
+import {
+    IsBoolean,
+    IsDate,
+    IsDateString,
+    IsEnum,
+    IsInteger,
+    IsNested,
+    IsString,
+    IsUUID,
+} from './decorators';
+import {
+    IsBooleanOptions,
+    IsDateOptions,
+    IsDateStringOptions,
+    IsEnumOptions,
+    IsIntegerOptions,
+    IsNestedOptions,
+    IsStringOptions,
+    IsUUIDOptions,
+} from './options';
+import {
+    PropertyDecoratorFactory,
+    PropertyDecoratorTransformer,
+} from './types';
+
+/* The library provides a set of decorator factories.
+ *
+ * Each factory takes options and return a `PropertyDecorator`. These factories can be imported directly and,
+ * more importantly, can be referenced as a single type that can be  *tranformed* into another implementation.
+ */
+export interface DTODecoratorFactories {
+    IsBoolean: PropertyDecoratorFactory<IsBooleanOptions>;
+    IsDate: PropertyDecoratorFactory<IsDateOptions>;
+    IsDateString: PropertyDecoratorFactory<IsDateStringOptions>;
+    IsEnum: PropertyDecoratorFactory<IsEnumOptions>;
+    IsInteger: PropertyDecoratorFactory<IsIntegerOptions>;
+    IsNested: PropertyDecoratorFactory<IsNestedOptions>;
+    IsString: PropertyDecoratorFactory<IsStringOptions>;
+    IsUUID: PropertyDecoratorFactory<IsUUIDOptions>;
+}
+
+/* The factories provided by this library (only) write options as metadata.
+ */
+export const FACTORIES: DTODecoratorFactories = {
+    IsBoolean,
+    IsDate,
+    IsDateString,
+    IsEnum,
+    IsInteger,
+    IsNested,
+    IsString,
+    IsUUID,
+};
+
+/* The factories can be transformed into an alternate implementation.
+ */
+export type DTODecoratorTransformers = {
+    [Key in keyof DTODecoratorFactories]?: PropertyDecoratorTransformer;
+};
+
+/* Applying a transformer to a factory produces a new factory.
+ */
+export function applyTransformer<Options>(
+    factory: PropertyDecoratorFactory<Options>,
+    transformer: PropertyDecoratorTransformer = (decorator: PropertyDecorator) => decorator,
+): PropertyDecoratorFactory<Options> {
+    return (options: Options) => transformer(factory(options));
+}
+
+/* An implementation can produce its own factories using `buildDecoratorFactories` to map over the factories.
+ */
+export function buildDecoratorFactories(
+    transformers: DTODecoratorTransformers,
+    decorators: DTODecoratorFactories = FACTORIES,
+): DTODecoratorFactories {
+    return Object.fromEntries(
+        Object.entries(decorators).map(
+            ([key, factory]: [string, PropertyDecoratorFactory<unknown>]) => ([
+                key,
+                applyTransformer(
+                    factory,
+                    transformers[key as keyof DTODecoratorFactories],
+                ),
+            ]),
+        ),
+    ) as unknown as DTODecoratorFactories;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
+export * from './api';
 export * from './decorators';
 export * from './enums';
 export * from './metadata';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
 export * from './constructor.type';
+export * from './property-decorator-factory.type';
+export * from './property-decorator-transformer.type';
 export * from './target.type';

--- a/src/types/property-decorator-factory.type.ts
+++ b/src/types/property-decorator-factory.type.ts
@@ -1,0 +1,3 @@
+export interface PropertyDecoratorFactory<Options> {
+    (options: Options): PropertyDecorator;
+}

--- a/src/types/property-decorator-transformer.type.ts
+++ b/src/types/property-decorator-transformer.type.ts
@@ -1,0 +1,1 @@
+export type PropertyDecoratorTransformer = (decorator: PropertyDecorator) => PropertyDecorator;


### PR DESCRIPTION
The main goals of this library are to:

 1. Define a set of generally applicable DTO decorators types.
 2. Allow other libraries to implement alternative decorators that leverage specific libries.

This PR adds a mechanism for achieving the latter via a transformation layer.