### PR TITLE
Allow composition of optional decorators.

### DIFF
--- a/src/types/dto-decorator-factories.type.ts
+++ b/src/types/dto-decorator-factories.type.ts
@@ -13,11 +13,13 @@ export type DTODecoratorFactories = {
 /* Multiple property decorators can be composed into a new property decorator.
  */
 export function composePropertyDecorators(
-    decorators: PropertyDecorator[],
+    decorators: Array<PropertyDecorator | undefined>,
 ): PropertyDecorator {
     return (target: Target, propertyKey: string | symbol): void => {
         for (const decorator of decorators) {
-            decorator(target, propertyKey);
+            if (decorator !== undefined) {
+                decorator(target, propertyKey);
+            }
         }
     };
 }


### PR DESCRIPTION
Some of our decorator recipes have conditional logic; it's nice if these recipes
can use an array of property decorators or undefined.