### PR TITLE
Make composeDecoratorFactories generic

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -10,9 +10,11 @@ import {
 
 /* Consumers that wish to define their own behavior may compose sets of these decorator factories together.
  */
-export function composeDecoratorFactories(
-    factories: DTODecoratorFactories[],
-): DTODecoratorFactories {
+export function composeDecoratorFactories<
+    CustomDTODecoratorFactories extends DTODecoratorFactories = DTODecoratorFactories,
+>(
+    factories: (DTODecoratorFactories | CustomDTODecoratorFactories)[],
+): CustomDTODecoratorFactories {
     return Object.keys(NOOP_DECORATORS).reduce(
         (acc, name) => ({
             ...acc,
@@ -23,6 +25,6 @@ export function composeDecoratorFactories(
                 ),
             ),
         }),
-        {} as DTODecoratorFactories,
+        {} as CustomDTODecoratorFactories,
     );
 }


### PR DESCRIPTION
Make `composeDecoratorFactories` generic to allow extend `DTODecoratorFactories`.

## Problem
Currently we are not able to run `composeDecoratorFactories` having factories with type extending `DTODecoratorFactories`. We can cast it manually, but this small change might improve usage experience and result in an answer with correct type.

## Proposal
I propose to make `composeDecoratorFactories` generic to allow users to use this functions with types extending the original one without a need of manual casting.